### PR TITLE
Fix GetShortAssemblyQualifiedName to work properly with generic types.

### DIFF
--- a/SharpYaml/Serialization/SerializerContext.cs
+++ b/SharpYaml/Serialization/SerializerContext.cs
@@ -58,8 +58,8 @@ namespace SharpYaml.Serialization
 		private readonly SerializerSettings settings;
 		private readonly ITagTypeRegistry tagTypeRegistry;
 		private readonly ITypeDescriptorFactory typeDescriptorFactory;
-	    private IEmitter emitter;
-	    private readonly SerializerContextSettings contextSettings;
+		private IEmitter emitter;
+		private readonly SerializerContextSettings contextSettings;
 		internal int AnchorCount;
 
 		/// <summary>
@@ -71,13 +71,13 @@ namespace SharpYaml.Serialization
 		{
 			Serializer = serializer;
 			settings = serializer.Settings;
-		    tagTypeRegistry = settings.AssemblyRegistry;
+			tagTypeRegistry = settings.AssemblyRegistry;
 			ObjectFactory = settings.ObjectFactory;
-		    ObjectSerializerBackend = settings.ObjectSerializerBackend;
+			ObjectSerializerBackend = settings.ObjectSerializerBackend;
 			Schema = Settings.Schema;
-		    ObjectSerializer = serializer.ObjectSerializer;
+			ObjectSerializer = serializer.ObjectSerializer;
 			typeDescriptorFactory = serializer.TypeDescriptorFactory;
-		    contextSettings = serializerContextSettings ?? SerializerContextSettings.Default;
+			contextSettings = serializerContextSettings ?? SerializerContextSettings.Default;
 		}
 
 		/// <summary>
@@ -97,7 +97,7 @@ namespace SharpYaml.Serialization
 		/// </value>
 		public SerializerContextSettings ContextSettings
 		{
-		    get { return contextSettings; }
+			get { return contextSettings; }
 		}
 
 		/// <summary>
@@ -127,11 +127,11 @@ namespace SharpYaml.Serialization
 		/// <value>The reader.</value>
 		public EventReader Reader { get; set; }
 
-        /// <summary>
-        /// Gets the object serializer backend.
-        /// </summary>
-        /// <value>The object serializer backend.</value>
-        public IObjectSerializerBackend ObjectSerializerBackend { get; private set; }
+		/// <summary>
+		/// Gets the object serializer backend.
+		/// </summary>
+		/// <value>The object serializer backend.</value>
+		public IObjectSerializerBackend ObjectSerializerBackend { get; private set; }
 
 		private IYamlSerializable ObjectSerializer { get; set; }
 
@@ -143,11 +143,11 @@ namespace SharpYaml.Serialization
 		/// </value>
 		public bool AllowErrors { get; set; }
 
-        /// <summary>
-        /// Gets a value indicating whether the deserialization has generated some remap.
-        /// </summary>
-        /// <value><c>true</c> if the deserialization has generated some remap; otherwise, <c>false</c>.</value>
-        public bool HasRemapOccurred { get; internal set; }
+		/// <summary>
+		/// Gets a value indicating whether the deserialization has generated some remap.
+		/// </summary>
+		/// <value><c>true</c> if the deserialization has generated some remap; otherwise, <c>false</c>.</value>
+		public bool HasRemapOccurred { get; internal set; }
 
 		/// <summary>
 		/// Gets or sets the member mask that will be used to filter <see cref="YamlMemberAttribute.Mask"/>.
@@ -168,13 +168,15 @@ namespace SharpYaml.Serialization
 			var node = Reader.Parser.Current;
 			try
 			{
-                var objectContext = new ObjectContext(this, value, FindTypeDescriptor(expectedType));
-                return ObjectSerializer.ReadYaml(ref objectContext);
+				var objectContext = new ObjectContext(this, value, FindTypeDescriptor(expectedType));
+				return ObjectSerializer.ReadYaml(ref objectContext);
+			}
+			catch (YamlException)
+			{
+				throw;
 			}
 			catch (Exception ex)
 			{
-				if (ex is YamlException)
-					throw;
 				throw new YamlException(node.Start, node.End, "Error while deserializing node [{0}]".DoFormat(node), ex);
 			}
 		}
@@ -191,23 +193,23 @@ namespace SharpYaml.Serialization
 		/// <value>The writer.</value>
 		public IEventEmitter Writer { get; set; }
 
-        /// <summary>
-        /// Gets the emitter.
-        /// </summary>
-        /// <value>The emitter.</value>
-	    public IEmitter Emitter
-	    {
-	        get { return emitter; }
-	        internal set { emitter = value; }
-	    }
+		/// <summary>
+		/// Gets the emitter.
+		/// </summary>
+		/// <value>The emitter.</value>
+		public IEmitter Emitter
+		{
+			get { return emitter; }
+			internal set { emitter = value; }
+		}
 
-	    /// <summary>
+		/// <summary>
 		/// The default function to write an object to Yaml
 		/// </summary>
 		public void WriteYaml(object value, Type expectedType, YamlStyle style = YamlStyle.Any)
 		{
-            var objectContext = new ObjectContext(this, value, FindTypeDescriptor(expectedType)) { Style = style };
-            ObjectSerializer.WriteYaml(ref objectContext);
+			var objectContext = new ObjectContext(this, value, FindTypeDescriptor(expectedType)) { Style = style };
+			ObjectSerializer.WriteYaml(ref objectContext);
 		}
 
 		/// <summary>
@@ -217,16 +219,16 @@ namespace SharpYaml.Serialization
 		/// <returns>An instance of <see cref="ITypeDescriptor"/>.</returns>
 		public ITypeDescriptor FindTypeDescriptor(Type type)
 		{
-            return typeDescriptorFactory.Find(type, Settings.ComparerForKeySorting);
+			return typeDescriptorFactory.Find(type, Settings.ComparerForKeySorting);
 		}
 
-	    /// <summary>
-	    /// Resolves a type from the specified tag.
-	    /// </summary>
-	    /// <param name="tagName">Name of the tag.</param>
-	    /// <param name="isAlias"></param>
-	    /// <returns>Type.</returns>
-	    public Type TypeFromTag(string tagName, out bool isAlias)
+		/// <summary>
+		/// Resolves a type from the specified tag.
+		/// </summary>
+		/// <param name="tagName">Name of the tag.</param>
+		/// <param name="isAlias"></param>
+		/// <returns>Type.</returns>
+		public Type TypeFromTag(string tagName, out bool isAlias)
 		{
 			return tagTypeRegistry.TypeFromTag(tagName, out isAlias);
 		}

--- a/SharpYaml/TypeExtensions.cs
+++ b/SharpYaml/TypeExtensions.cs
@@ -46,6 +46,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace SharpYaml
 {
@@ -58,25 +59,25 @@ namespace SharpYaml
 			return type.GetInterface(lookInterfaceType) != null;
 		}
 
-	    public static bool ExtendsGeneric(this Type type, Type genericType)
-	    {
-	        if (genericType == null) throw new ArgumentNullException("genericType");
-            if (!genericType.IsGenericTypeDefinition) throw new ArgumentException("Expecting a generic type definition", "genericType");
+		public static bool ExtendsGeneric(this Type type, Type genericType)
+		{
+			if (genericType == null) throw new ArgumentNullException("genericType");
+			if (!genericType.IsGenericTypeDefinition) throw new ArgumentException("Expecting a generic type definition", "genericType");
 
-	        var nextType = type;
-	        while (nextType != null)
-	        {
-                var checkType = nextType.IsGenericType ? nextType.GetGenericTypeDefinition() : nextType;
-                if (checkType == genericType)
-	            {
-	                return true;
-	            }
-	            nextType = nextType.BaseType;
-	        }
-	        return false;
-	    }
+			var nextType = type;
+			while (nextType != null)
+			{
+				var checkType = nextType.IsGenericType ? nextType.GetGenericTypeDefinition() : nextType;
+				if (checkType == genericType)
+				{
+					return true;
+				}
+				nextType = nextType.BaseType;
+			}
+			return false;
+		}
 
-	    public static Type GetInterface(this Type type, Type lookInterfaceType)
+		public static Type GetInterface(this Type type, Type lookInterfaceType)
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
@@ -109,25 +110,67 @@ namespace SharpYaml
 		/// </summary>
 		/// <param name="type">The type.</param>
 		/// <returns>The assembly qualified name of the type, but without the assembly version or public token.</returns>
-		/// <exception cref="System.InvalidOperationException">Unable to get an assembly qualified name for type [{0}].DoFormat(type)</exception>
+		/// <exception cref="InvalidOperationException">Unable to get an assembly qualified name for type.</exception>
 		public static string GetShortAssemblyQualifiedName(this Type type)
 		{
-			var typeName = type.AssemblyQualifiedName;
-			if (typeName == null)
-			{
-				throw new InvalidOperationException("Unable to get an assembly qualified name for type [{0}]".DoFormat(type));
-			}
+			if (type.AssemblyQualifiedName == null)
+				throw new InvalidOperationException($"Unable to get an assembly qualified name for type [{type}]");
 
-			var indexAfterType = typeName.IndexOf(',');
-			if (indexAfterType >= 0)
+			var sb = new StringBuilder();
+			DoGetShortAssemblyQualifiedName(type, sb);
+			return sb.ToString();
+		}
+
+		private static void DoGetShortAssemblyQualifiedName(Type type, StringBuilder sb, bool appendAssemblyName = true)
+		{
+			// namespace
+			sb.Append(type.Namespace).Append(".");
+			// nested declaring types
+			var declaringType = type.DeclaringType;
+			if (declaringType != null)
 			{
-				var indexAfterAssembly = typeName.IndexOf(',', indexAfterType + 1);
-				if (indexAfterAssembly >= 0)
+				var declaringTypeName = string.Empty;
+				do
 				{
-					typeName = typeName.Substring(0, indexAfterAssembly).Replace(" ", string.Empty);
-				}
+					declaringTypeName = declaringType.Name + "+" + declaringTypeName;
+					declaringType = declaringType.DeclaringType;
+				} while (declaringType != null);
+				sb.Append(declaringTypeName);
 			}
-			return typeName;
+			// type
+			sb.Append(type.Name);
+			// generic arguments
+			if (type.IsGenericType)
+			{
+				sb.Append("[[");
+				var genericArguments = type.GetGenericArguments();
+				DoGetShortAssemblyQualifiedName(genericArguments[0], sb);
+				for (var i = 1; i < genericArguments.Length; i++)
+				{
+					sb.Append("],[");
+					DoGetShortAssemblyQualifiedName(genericArguments[i], sb);
+				}
+				sb.Append("]]");
+			}
+			// assembly
+			if (appendAssemblyName)
+				sb.Append(",").Append(GetShortAssemblyName(type.Assembly));
+		}
+
+		/// <summary>
+		/// Gets the qualified name of the assembly, but without the assembly version or public token.
+		/// </summary>
+		/// <param name="assembly">The assembly.</param>
+		/// <returns>The qualified name of the assembly, but without the assembly version or public token.</returns>
+		public static string GetShortAssemblyName(this Assembly assembly)
+		{
+			var assemblyName = assembly.FullName;
+			var indexAfterAssembly = assemblyName.IndexOf(',');
+			if (indexAfterAssembly >= 0)
+			{
+				assemblyName = assemblyName.Substring(0, indexAfterAssembly);
+			}
+			return assemblyName;
 		}
 
 		/// <summary>
@@ -162,7 +205,7 @@ namespace SharpYaml
 		/// <returns><c>true</c> if the specified type is nullable; otherwise, <c>false</c>.</returns>
 		public static bool IsNullable(this Type type)
 		{
-			return Nullable.GetUnderlyingType(type) != null;			
+			return Nullable.GetUnderlyingType(type) != null;
 		}
 
 		/// <summary>

--- a/SharpYaml/TypeExtensions.cs
+++ b/SharpYaml/TypeExtensions.cs
@@ -121,7 +121,7 @@ namespace SharpYaml
 		public static string GetShortAssemblyQualifiedName(this Type type)
 		{
 			if (type.AssemblyQualifiedName == null)
-				throw new InvalidOperationException($"Unable to get an assembly qualified name for type [{type}]");
+				throw new InvalidOperationException("Unable to get an assembly qualified name for type [{0}]".DoFormat(type));
 
 			var sb = new StringBuilder();
 			DoGetShortAssemblyQualifiedName(type, sb);

--- a/SharpYaml/TypeExtensions.cs
+++ b/SharpYaml/TypeExtensions.cs
@@ -138,6 +138,9 @@ namespace SharpYaml
 				sb.Append(declaringTypeName);
 			}
 			// type
+		    var isArray = type.IsArray;
+		    if (isArray)
+                type = type.GetElementType();
 			sb.Append(type.Name);
 			// generic arguments
 			if (type.IsGenericType)
@@ -152,6 +155,8 @@ namespace SharpYaml
 				}
 				sb.Append("]]");
 			}
+		    if (isArray)
+		        sb.Append("[]");
 			// assembly
 			if (appendAssemblyName)
 				sb.Append(",").Append(GetShortAssemblyName(type.Assembly));

--- a/SharpYaml/TypeExtensions.cs
+++ b/SharpYaml/TypeExtensions.cs
@@ -111,6 +111,13 @@ namespace SharpYaml
 		/// <param name="type">The type.</param>
 		/// <returns>The assembly qualified name of the type, but without the assembly version or public token.</returns>
 		/// <exception cref="InvalidOperationException">Unable to get an assembly qualified name for type.</exception>
+		/// <example>
+		///     <list type="bullet">
+		///         <item><c>typeof(string).GetShortAssemblyQualifiedName(); // System.String,mscorlib</c></item>
+		///         <item><c>typeof(string[]).GetShortAssemblyQualifiedName(); // System.String[],mscorlib</c></item>
+		///         <item><c>typeof(List&lt;string&gt;).GetShortAssemblyQualifiedName(); // System.Collection.Generics.List`1[[System.String,mscorlib]],mscorlib</c></item>
+		///     </list>
+		/// </example>
 		public static string GetShortAssemblyQualifiedName(this Type type)
 		{
 			if (type.AssemblyQualifiedName == null)
@@ -138,9 +145,9 @@ namespace SharpYaml
 				sb.Append(declaringTypeName);
 			}
 			// type
-		    var isArray = type.IsArray;
-		    if (isArray)
-                type = type.GetElementType();
+			var isArray = type.IsArray;
+			if (isArray)
+				type = type.GetElementType();
 			sb.Append(type.Name);
 			// generic arguments
 			if (type.IsGenericType)
@@ -155,8 +162,8 @@ namespace SharpYaml
 				}
 				sb.Append("]]");
 			}
-		    if (isArray)
-		        sb.Append("[]");
+			if (isArray)
+				sb.Append("[]");
 			// assembly
 			if (appendAssemblyName)
 				sb.Append(",").Append(GetShortAssemblyName(type.Assembly));

--- a/SharpYaml/TypeExtensions.cs
+++ b/SharpYaml/TypeExtensions.cs
@@ -154,10 +154,10 @@ namespace SharpYaml
 			{
 				sb.Append("[[");
 				var genericArguments = type.GetGenericArguments();
-				DoGetShortAssemblyQualifiedName(genericArguments[0], sb);
-				for (var i = 1; i < genericArguments.Length; i++)
+				for (var i = 0; i < genericArguments.Length; i++)
 				{
-					sb.Append("],[");
+					if (i > 0)
+						sb.Append("],[");
 					DoGetShortAssemblyQualifiedName(genericArguments[i], sb);
 				}
 				sb.Append("]]");


### PR DESCRIPTION
Type like List<string> were not serialized correctly.

New implementation does not rely on `Type.AssemblyQualifiedName` but instead computes the simplified full name from the type properties.

I think it is easier to maintain than parsing the assembly the qualified name and replacing part of it.